### PR TITLE
contact section create and sent modal design setting

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -67,6 +67,6 @@ h2 {
 }
 
 h3 {
-    font-size: 1.5rem;
+    font-size: 1.4rem;
     font-weight: bold;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -69,13 +69,12 @@ main {
             flex: 1;
             min-width: 250px;
             max-width: 550px;
-            min-height: 600px;
+            min-height: 550px;
             margin: 1rem;
             padding: 1.5rem;
             background-color: white;
             box-shadow: 3px 3px 8px rgba(100, 100, 100, 0.3);
             border-radius: 12px;
-            text-align: center;
             transition: all 0.3s;
 
             img {
@@ -90,8 +89,11 @@ main {
                 flex-direction: column;
                 flex-grow: 1;
                 padding: 1rem;
+                h3 {
+                    text-align: center;
+                }
                 p {
-                    flex-grow: 1;
+                    font-size: 0.9rem;
                 }
                 .more_btn {
                     margin-top: auto; /* 一番下に配置 */
@@ -729,3 +731,89 @@ footer {
 
 /* #business {
 } */
+
+/* contact要素 */
+#contact {
+    .container {
+        padding: 2rem;
+        margin: 0 auto;
+        max-width: 800px;
+        p {
+            font-size: 1.2rem;
+            margin-bottom: 2rem;
+        }
+
+        form {
+            width: 80%;
+            max-width: 500px;
+        }
+        .form_body {
+            margin-bottom: 2rem;
+            .form_label {
+                font-weight: bold;
+                margin-bottom: 0.5rem;
+                label {
+                    vertical-align: middle;
+                }
+                .required {
+                    display: inline-block;
+                    color: red;
+                    font-size: 0.8rem;
+                    margin-left: 0.5rem;
+                    vertical-align: middle;
+                }
+            }
+            input[type="text"],
+            input[type="email"],
+            input[type="tel"] {
+                width: 100%;
+                padding: 0.5rem;
+                margin-bottom: 1rem;
+                border: 1px solid #ccc;
+                border-radius: 5px;
+            }
+            textarea {
+                width: 100%;
+                padding: 0.5rem;
+                margin-bottom: 1rem;
+                border: 1px solid #ccc;
+                border-radius: 5px;
+                min-height: 300px;
+            }
+        }
+
+        .privacy_policy {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            font-size: 0.8rem;
+            margin-bottom: 1rem;
+            a {
+                color: #005eff;
+                text-decoration: underline;
+                margin-bottom: 0.5rem;
+            }
+            label .required {
+                display: inline-block;
+                color: red;
+                font-size: 0.8rem;
+                margin-left: 0.5rem;
+                vertical-align: middle;
+            }
+        }
+        .mdl_btn {
+            display: block;
+            text-align: center;
+            margin: 0 auto;
+        }
+    }
+
+    @media screen and (max-width: 768px) {
+        .container {
+            p {
+                font-size: 1rem;
+            }
+        }
+    }
+}

--- a/index.html
+++ b/index.html
@@ -177,48 +177,138 @@
             </section>
 
             <!-- お問い合わせフォーム -->
-            <section id="contact" class="contact">
-                <h2>お問い合わせ</h2>
-                <form>
-                    <input
-                        type="text"
-                        name="name"
-                        placeholder="お名前"
-                        required
-                    />
-                    <input
-                        type="email"
-                        name="email"
-                        placeholder="メールアドレス"
-                        required
-                    />
-                    <input
-                        type="text"
-                        name="company"
-                        placeholder="会社名"
-                        required
-                    />
-                    <input
-                        type="tel"
-                        name="tel"
-                        placeholder="電話番号"
-                        required
-                    />
-                    <textarea
-                        name="message"
-                        placeholder="お問い合わせ内容"
-                        required
-                    ></textarea>
+            <section id="contact">
+                <div class="container">
+                    <h2>お問い合わせ</h2>
+                    <p>
+                        お問い合わせ内容をご入力の上、「入力内容を確認」ボタンを押してください。
+                    </p>
+                    <form id="form">
+                        <div class="form_body">
+                            <div class="form_label">
+                                <label for="name">お名前</label
+                                ><span class="required">※必須</span>
+                            </div>
+                            <div class="form_input">
+                                <input
+                                    type="text"
+                                    id="name"
+                                    name="name"
+                                    autocomplete="name"
+                                    required
+                                />
+                            </div>
+                        </div>
 
-                    <!-- プライバシーポリシー同意チェックボックス -->
-                    <div class="privacy_policy">
-                        <a href="policy">プライバシーポリシーを確認する</a>
-                        <label>
-                            <input type="checkbox" required />
-                            <span>プライバシーポリシーに同意する</span>
-                        </label>
-                    </div>
-                </form>
+                        <div class="form_body">
+                            <div class="form_label">
+                                <label for="email">メールアドレス</label
+                                ><span class="required">※必須</span>
+                            </div>
+                            <div class="form_input">
+                                <input
+                                    type="email"
+                                    id="email"
+                                    name="email"
+                                    autocomplete="email"
+                                    required
+                                />
+                            </div>
+                        </div>
+                        <div class="form_body">
+                            <div class="form_label">
+                                <label for="organization">会社名</label>
+                            </div>
+                            <div class="form_input">
+                                <input
+                                    type="text"
+                                    id="organization"
+                                    name="organization"
+                                    autocomplete="organization"
+                                />
+                            </div>
+                        </div>
+                        <div class="form_body">
+                            <div class="form_label">
+                                <label for="tel">電話番号</label>
+                            </div>
+                            <div class="form_input">
+                                <input
+                                    type="tel"
+                                    id="tel"
+                                    name="tel"
+                                    autocomplete="tel"
+                                />
+                            </div>
+                        </div>
+                        <div class="form_body">
+                            <div class="form_label">
+                                <label for="detail">お問い合わせ内容</label>
+                                <span class="required">※必須</span>
+                            </div>
+                            <div class="form_input">
+                                <textarea
+                                    id="detail"
+                                    name="detail"
+                                    required
+                                ></textarea>
+                            </div>
+                        </div>
+
+                        <!-- プライバシーポリシー同意チェックボックス -->
+                        <div class="privacy_policy">
+                            <a href="#">プライバシーポリシーを確認する</a>
+                            <label>
+                                <input type="checkbox" required />
+                                <span>プライバシーポリシーに同意する</span>
+                                <span class="required">※必須</span>
+                            </label>
+                        </div>
+
+                        <button
+                            class="more_btn mdl_btn"
+                            type="button"
+                            onclick="openConfirmDialog()"
+                        >
+                            入力内容を確認
+                        </button>
+                    </form>
+                </div>
+
+                <dialog id="confirmDialog">
+                    <h2>入力内容の確認</h2>
+                    <p>
+                        <strong>お名前:</strong> <span id="confirm_name"></span>
+                    </p>
+                    <p>
+                        <strong>メールアドレス:</strong>
+                        <span id="confirm_email"></span>
+                    </p>
+                    <p>
+                        <strong>会社名:</strong>
+                        <span id="confirm_organization"></span>
+                    </p>
+                    <p>
+                        <strong>電話番号:</strong>
+                        <span id="confirm_tel"></span>
+                    </p>
+                    <p>
+                        <strong>お問い合わせ内容:</strong>
+                        <span id="confirm_detail"></span>
+                    </p>
+
+                    <button onclick="submitForm()">送信する</button>
+                    <button onclick="closeConfirmDialog()">修正する</button>
+                </dialog>
+
+                <dialog id="successDialog">
+                    <h2>ありがとうございます。送信が完了しました。</h2>
+                    <p>
+                        追って担当者よりご連絡差し上げます。<br />
+                        しばらく経っても返信ない場合は、お手数ですがフォームより再度お問い合わせいただきますようお願いいたします。
+                    </p>
+                    <button onclick="closeSuccessDialog()">OK</button>
+                </dialog>
             </section>
         </main>
 

--- a/js/main.js
+++ b/js/main.js
@@ -22,3 +22,38 @@ document.querySelectorAll(".more_btn").forEach((button) => {
         }
     });
 });
+
+// モーダル関連
+function openConfirmDialog() {
+    // 入力内容を取得
+    document.getElementById("confirm_name").textContent =
+        document.getElementById("name").value;
+    document.getElementById("confirm_email").textContent =
+        document.getElementById("email").value;
+    document.getElementById("confirm_organization").textContent =
+        document.getElementById("organization").value;
+    document.getElementById("confirm_tel").textContent =
+        document.getElementById("tel").value;
+    document.getElementById("confirm_detail").textContent =
+        document.getElementById("detail").value;
+
+    // 確認モーダルを表示
+    document.getElementById("confirmDialog").showModal();
+}
+
+function closeConfirmDialog() {
+    document.getElementById("confirmDialog").close();
+}
+
+function submitForm() {
+    // 確認モーダルを閉じる
+    document.getElementById("confirmDialog").close();
+
+    // 送信完了モーダルを表示
+    document.getElementById("successDialog").showModal();
+}
+
+function closeSuccessDialog() {
+    document.getElementById("successDialog").close();
+    document.getElementById("contactForm").reset(); // フォームをリセット
+}


### PR DESCRIPTION
お問い合わせ欄を作成。
デザインを反映させ、送信前の確認モダールまで。
実際の挙動は他のデザイン終わってからの実装にするため

- 送信押してもどこにも送られない
- ※必須事項に何も入れなくてもモーダル開いてしまう
- モーダルの修正押さないとモーダル閉じない

色々と調整は必要。

次はヘッダーのタブデザイン及びアコーディオンのセッティング。