### PR TITLE
header tab underline setting but acordions are not setting

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -168,24 +168,47 @@ header {
     position: fixed;
     width: 100%;
     z-index: 3;
+    box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1);
 
     nav {
         padding: 10px;
-        a {
-            color: #1e1e1e;
-            margin: 0 10px;
-            text-decoration: none;
-            font-weight: bold;
-        }
         .nav_items {
             display: flex;
             align-items: center;
+            gap: 1rem;
             .nav_list {
                 display: flex;
                 align-items: center;
                 position: relative;
                 height: 40px;
-                padding: 0 0.5rem;
+                justify-content: center;
+                transition: all 0.3s ease-in-out;
+                a {
+                    color: #1e1e1e;
+                    margin: 0 10px;
+                    text-decoration: none;
+                    font-weight: bold;
+                    padding: 0.5rem 1rem;
+                    border-radius: 20px;
+                    transition: all 0.3s ease-in-out;
+                }
+            }
+
+            /* 下線アニメーション */
+            .nav_list:not(.contact_btn)::after {
+                content: "";
+                position: absolute;
+                bottom: -4px;
+                left: 50%;
+                width: 0;
+                height: 2px;
+                background-color: #233270;
+                transition: all 0.3s ease-in-out;
+                transform: translateX(-50%);
+            }
+
+            .nav_list:hover::after {
+                width: 80%;
             }
 
             .contact_btn a {
@@ -228,7 +251,7 @@ header {
     background: #000;
     position: absolute;
     top: 0;
-    left: 0;
+    right: calc(100% + 7px);
 }
 
 .nav_list:first-child::before {
@@ -332,7 +355,6 @@ header {
                     background: #000;
                     position: absolute;
                     bottom: -1px;
-                    left: 0;
                 }
                 .contact_btn a {
                     padding: 1.5rem;


### PR DESCRIPTION
ヘッダーの各項目にホバーするとアンダーラインが引かれるように設定。
ただし、アコーディオンは未実装。

- アコーディオンにするほどコンテンツがない。
- 表示を簡略化しすぎると探す手間が増えるだけ。
- 今現在いるページについては下線を固定化する予定だが、まだページがないので後回し。

index.htmlの構成は大まかに完了。
会社情報を皮切りに各種コンテンツを配置していく。