### PR TITLE
accordion action setting and delete items reproducted

### DIFF
--- a/arc.php
+++ b/arc.php
@@ -246,7 +246,9 @@ include 'header.php';
                 <li class="card_list nf">
                     <button class="accordion_header">長野県安曇野市 宮城小水力発電所</button>
                     <div class="accordion_content">
-                        <img src="/img/azumino_pic.webp" alt="安曇野宮城小水力発電所" />
+                        <div class="card_img">
+                            <img src="/img/azumino_pic.webp" alt="安曇野宮城小水力発電所" />
+                        </div>
                         <table>
                             <tr>
                                 <th>使用流量</th>
@@ -278,7 +280,10 @@ include 'header.php';
                 <li class="card_list nf">
                     <button class="accordion_header">岩手県花巻市 松沢川小水力発電所</button>
                     <div class="accordion_content">
-                        <img src="/img/hanamaki.webp" alt="松沢川小水力発電所" />
+                        <div class="card_img">
+
+                            <img src="/img/hanamaki.webp" alt="松沢川小水力発電所" />
+                        </div>
                         <table>
                             <tr>
                                 <th>使用流量</th>
@@ -314,7 +319,10 @@ include 'header.php';
                 <li class="card_list nf">
                     <button class="accordion_header">宮崎県えびの市 田代陣の池ホタル谷発電所</button>
                     <div class="accordion_content">
-                        <img src="/img/Ebino.webp" alt="田代陣の池ホタル谷発電所" />
+                        <div class="card_img">
+
+                            <img src="/img/Ebino.webp" alt="田代陣の池ホタル谷発電所" />
+                        </div>
                         <table>
                             <tr>
                                 <th>使用流量</th>

--- a/css/style.css
+++ b/css/style.css
@@ -186,19 +186,17 @@ main {
         }
 
         .card_items {
-            display: flex;
-            flex-wrap: wrap;
-            justify-content: center;
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            /* grid-auto-rows: minmax(150px, auto); */
+            align-items: start; /* 上端揃え */
+            gap: 1rem;
+            padding: 1rem 0;
 
             .card_list {
                 display: flex;
                 flex-direction: column;
-                align-items: center;
                 justify-content: space-between;
-                flex: 1;
-                min-width: 250px;
-                max-width: 550px;
-                min-height: 550px;
                 margin: 1rem;
                 padding: 1.5rem;
                 background-color: white;
@@ -276,17 +274,35 @@ main {
                 background-color: #f5f5f5;
                 border: none;
                 text-align: left;
-                padding: 0.5rem;
+                padding: 0.5rem 2.1rem 0.5rem 0.5rem;
                 font-weight: bold;
                 font-size: 1rem;
                 cursor: pointer;
                 border-bottom: 2px solid #ccc;
+                position: relative;
+            }
+
+            .accordion_header::after {
+                content: "";
+                width: 16px;
+                height: 16px;
+                background: url("../img/down.svg") no-repeat center center;
+                background-size: contain;
+                position: absolute;
+                top: 50%;
+                right: 0.5rem;
+                transform: translateY(-50%);
+                transition: all 0.3s;
+            }
+
+            .accordion_header.active::after {
+                background: url("../img/Up.svg") no-repeat center center;
             }
 
             .accordion_content {
                 overflow: hidden;
                 max-height: 0;
-                transition: max-height 0.4s ease, padding 0.4s ease;
+                transition: max-height 0.8s ease, padding 0.8s ease;
                 padding: 0 0.5rem;
 
                 table {
@@ -416,13 +432,6 @@ main {
             }
 
             .card_items {
-                flex-direction: column;
-                align-items: center;
-
-                .card_list {
-                    width: 90%;
-                }
-
                 .card_content {
                     .other_title {
                         font-size: 1.1rem;
@@ -549,14 +558,6 @@ main {
             }
 
             .card_items {
-                .card_list {
-                    .card_img {
-                        min-height: 200px;
-                        width: 100%;
-                        aspect-ratio: 18/16;
-                    }
-                }
-
                 p {
                     font-size: 0.9rem;
                 }

--- a/img/Up.svg
+++ b/img/Up.svg
@@ -1,0 +1,3 @@
+<svg width="13" height="8" viewBox="0 0 13 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.5 6.64941L6.5 1.64941L1.5 6.64941" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/img/down.svg
+++ b/img/down.svg
@@ -1,0 +1,3 @@
+<svg width="13" height="8" viewBox="0 0 13 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.5 1.64941L6.5 6.64941L11.5 1.64941" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/js/main.js
+++ b/js/main.js
@@ -18,18 +18,13 @@ document.querySelectorAll(".accordion_header").forEach((header) => {
             content.style.maxHeight = null;
             content.style.paddingTop = "0";
             content.style.paddingBottom = "0";
+            this.classList.remove("active");
         } else {
-            // まずすべて閉じる（複数開き防止）
-            document.querySelectorAll(".accordion_content").forEach((el) => {
-                el.style.maxHeight = null;
-                el.style.paddingTop = "0";
-                el.style.paddingBottom = "0";
-            });
-
             // 対象だけ開く
             content.style.maxHeight = content.scrollHeight + "px";
             content.style.paddingTop = "1rem";
             content.style.paddingBottom = "1rem";
+            this.classList.add("active");
         }
     });
 });


### PR DESCRIPTION
アコーディオン開閉動作を修正。
ただし、ハンバーガーメニューは意図しない開閉を防ぐために現状維持。

gitignoreに追加する要素をgit履歴から消してプッシュしてしまうとファイル消えることがわかった。
迂闊にrmしない ＆ 履歴から復旧するためにも、あまりに一度に多くの変更をしない。

カードリストの幅が微妙だが、取り敢えずcruttoのページ作成を優先。