### PR TITLE
send encording fixed

### DIFF
--- a/send.php
+++ b/send.php
@@ -28,6 +28,7 @@ try {
     $mail->Password = $_ENV['SMTP_PASS'];
     $mail->SMTPSecure = $_ENV['SMTP_SECURE']; // ssl or tls
     $mail->Port = $_ENV['SMTP_PORT'];
+    $mail->CharSet = 'UTF-8';
 
     // mail settings
     $mail->setFrom($_ENV['SMTP_USER'], 'Webお問い合わせ');
@@ -55,6 +56,7 @@ try {
     $autoReply->Password = $_ENV['SMTP_PASS'];
     $autoReply->SMTPSecure = $_ENV['SMTP_SECURE'];
     $autoReply->Port = $_ENV['SMTP_PORT'];
+    $mail->CharSet = 'UTF-8';
 
     $autoReply->setFrom($_ENV['SMTP_USER'], '株式会社シーイーエム');
     $autoReply->addAddress($form['email'], $form['name']);


### PR DESCRIPTION
メール関連が文字化けするため、エンコーディングをUTF-8指定。

本番環境向けに設定継続