### PR TITLE
careless miss fixed

### DIFF
--- a/httpdocs/arc.php
+++ b/httpdocs/arc.php
@@ -209,7 +209,7 @@ include 'header.php';
                             alt="高落差地域" />
                     </div>
                     <div class="card_content">
-                        <div class="other_title">農業用水</div>
+                        <div class="other_title">高落差地域</div>
                         <p class="cent">※ 100kW超の発電は不得手</p>
                     </div>
                 </li>

--- a/httpdocs/crutto.php
+++ b/httpdocs/crutto.php
@@ -199,7 +199,7 @@ include 'header.php';
                 <li class="card_list nf">
                     <div class="card_img">
                         <img
-                            src="img/low_head.webp"
+                            src="img/river.webp"
                             alt="低落差地域" />
                     </div>
                     <div class="card_content">

--- a/httpdocs/policy.php
+++ b/httpdocs/policy.php
@@ -4,7 +4,7 @@ include 'header.php';
 ?>
 
 <main>
-    <section id="policy hd_space">
+    <section id="policy" class="hd_space">
         <div class="container pd">
             <h2>プライバシーポリシー</h2>
             <br>

--- a/httpdocs/send.php
+++ b/httpdocs/send.php
@@ -58,7 +58,7 @@ try {
     $autoReply->Password = $_ENV['SMTP_PASS'];
     $autoReply->SMTPSecure = $_ENV['SMTP_SECURE'];
     $autoReply->Port = $_ENV['SMTP_PORT'];
-    $mail->CharSet = 'UTF-8';
+    $autoReply->CharSet = 'UTF-8';
 
     $autoReply->setFrom($_ENV['SMTP_USER'], '株式会社シーイーエム');
     $autoReply->addAddress($form['email'], $form['name']);


### PR DESCRIPTION
細かいミスを修正。

- アルキメデスやcruttoの画像やミニタイトルの表記ミスを修正
- 自動返信の文字化け修正。自動返信の場合の変数は$autoReply
- .htaccessはローカルでは不要なので除外
- プライバシーポリシーのpadding-top修正。idで指定していたためclassに修正。

gridシステムでの構成に移行する