### PR TITLE
grid style apply to map container and about contents

### DIFF
--- a/httpdocs/css/style.css
+++ b/httpdocs/css/style.css
@@ -75,11 +75,6 @@ main {
             width: 70vw;
         }
 
-        .wd_sm {
-            width: 35vw;
-            padding: 1rem;
-        }
-
         .no_dc {
             background-color: initial;
             border: none;
@@ -137,17 +132,30 @@ main {
         }
 
         .img_text_list {
-            display: flex;
-            flex-wrap: wrap;
-            justify-content: space-evenly;
-            align-items: center;
+            display: grid;
+            grid-template-columns: 1fr 1fr;
             gap: 2rem;
+            align-items: start;
             width: 100%;
 
+            @media screen and (max-width: 768px) {
+                grid-template-columns: 1fr;
+            }
+
             .text_list {
+                display: grid;
+                gap: 1rem;
+                width: 100%;
+                padding: 1rem;
+
                 p,
                 ul {
                     margin: 0.5rem 0 1.5rem 0;
+                }
+
+                ul {
+                    list-style: disc;
+                    padding-left: 1.5rem;
                 }
             }
 
@@ -510,12 +518,6 @@ main {
             }
 
             .img_text_list {
-                flex-direction: column;
-                gap: 1rem;
-                .text_list {
-                    width: 90%;
-                    margin: 0 auto;
-                }
                 .img_list {
                     width: 90%;
                     margin: 0 auto;
@@ -1345,43 +1347,27 @@ footer {
         background-color: white;
         .img_text_list {
             .map_container {
-                display: flex;
-                flex-direction: column;
-                justify-content: center;
-                align-items: center;
+                display: grid;
+                gap: 1rem;
+                width: 100%;
+                padding: 1rem;
                 #map {
                     height: 50vh;
                     min-height: 400px;
-                    min-width: 400px;
+                    width: 100%;
                     border-radius: 8px;
-                    overflow: hidden;
                     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-                    margin: 1rem;
+                }
+                h3 {
+                    text-align: center;
                 }
                 p {
-                    margin: 0.5rem;
+                    margin: 0.5rem 0;
                     text-align: left;
                     span {
+                        display: block;
                         margin-top: 0.5rem;
-                    }
-                }
-            }
-        }
-        @media screen and (max-width: 940px) {
-            .img_text_list {
-                flex-direction: column;
-                gap: 1rem;
-                .text_list {
-                    width: 80%;
-                    margin: 0 auto;
-                }
-                .map_container {
-                    width: 80%;
-                    margin: 0 auto;
-                    #map {
-                        width: 100%;
-                        min-width: 0;
-                        min-height: 0;
+                        font-weight: bold;
                     }
                 }
             }
@@ -1389,8 +1375,10 @@ footer {
 
         @media screen and (max-width: 425px) {
             .img_text_list {
-                .text_list {
+                .text_list,
+                .map_container {
                     width: 90%;
+                    margin: 0 auto;
                 }
             }
         }


### PR DESCRIPTION
gridレイアウトをaboutページに適用。
本来他のページも適用されるが、取り敢えずmap関連がここだけなので一旦切り分け。

imgやtableが絡むページは次で修正。