### PR TITLE
grid style apply to img text contents but solar except

### DIFF
--- a/httpdocs/arc.php
+++ b/httpdocs/arc.php
@@ -41,8 +41,7 @@ include 'header.php';
                 </div>
             </div>
             <div class="img_text_list">
-
-                <div class="space_del">
+                <div class="img_list ar_tl">
                     <img
                         src="img/arc_style.webp"
                         alt="パワーアルキメデス全景" />
@@ -105,64 +104,64 @@ include 'header.php';
                     </p>
                 </div>
 
-                <ul class="card_items">
-                    <li class="card_list nf">
-                        <div class="card_img">
-                            <img
-                                src="img/low_head.webp"
-                                alt="低落差対応" />
-                        </div>
-                        <div class="card_content">
-                            <p class="other_title title_left"><span><i class="fa-regular fa-pen-to-square"></i> 低落差で発電可能</span></p>
-                            <p>
-                                多くの水力発電機は数10mの落差が必要で、長大な配管を敷設する手間と敷地が必要です。
-                            </p>
-                            <p>
-                                パワーアルキメデスは配管だけでなく開水路にも設置でき、数mの落差でも発電を可能としています。
-                            </p>
-                        </div>
-                    </li>
-                    <li class="card_list nf">
-                        <div class="card_img">
-                            <img
-                                src="img/mini_pic.webp"
-                                alt="シンプル構造" />
-                        </div>
-                        <div class="card_content">
-                            <p class="other_title title_left"><span><i class="fa-regular fa-pen-to-square"></i> 手早く設置可能なシンプル構造</span></p>
-                            <p>
-                                構造を徹底的にシンプル化。最短で半日の据付を可能とし長期間の止水困難な場所にも対応できます。
-                            </p>
-                            <p><small>
-                                    ※ 設置環境によっては時間要する可能性があります。<br>
-                                    ※ 水車発電機の設置のみ。配線や付帯設備工事等は別途。
-                                </small>
-                            </p>
-                        </div>
-                    </li>
-                    <li class="card_list nf">
-                        <div class="card_img">
-                            <img
-                                src="img/garbage.webp"
-                                alt="低落差対応" />
-                        </div>
-                        <div class="card_content">
-                            <p class="other_title title_left"><span><i class="fa-regular fa-pen-to-square"></i> 異物混入に強い構造</span></p>
-                            <p>
-                                大半の水車は異物混入に弱く、出力低下だけでなく致命的な故障の原因にもなり得ます。
-                            </p>
-                            <p>
-                                パワーアルキメデスはプロペラ状の羽根車を採用しているため、空き缶や落ち葉等の多くは通過して下流に排出されます。塵一つ許さないような精密な管理は必要ありません。
-                            </p>
-                            <p><small>
-                                    ※ 故障は発生し難くても、出力低下の要因にはなり得ます。<br>
-                                    ※ 万が一に備えて適切な除塵設備は必要です。
-                                </small>
-                            </p>
-                        </div>
-                    </li>
-                </ul>
             </div>
+            <ul class="card_items">
+                <li class="card_list nf">
+                    <div class="card_img">
+                        <img
+                            src="img/low_head.webp"
+                            alt="低落差対応" />
+                    </div>
+                    <div class="card_content">
+                        <p class="other_title title_left"><span><i class="fa-regular fa-pen-to-square"></i> 低落差で発電可能</span></p>
+                        <p>
+                            多くの水力発電機は数10mの落差が必要で、長大な配管を敷設する手間と敷地が必要です。
+                        </p>
+                        <p>
+                            パワーアルキメデスは配管だけでなく開水路にも設置でき、数mの落差でも発電を可能としています。
+                        </p>
+                    </div>
+                </li>
+                <li class="card_list nf">
+                    <div class="card_img">
+                        <img
+                            src="img/mini_pic.webp"
+                            alt="シンプル構造" />
+                    </div>
+                    <div class="card_content">
+                        <p class="other_title title_left"><span><i class="fa-regular fa-pen-to-square"></i> 手早く設置可能なシンプル構造</span></p>
+                        <p>
+                            構造を徹底的にシンプル化。最短で半日の据付を可能とし長期間の止水困難な場所にも対応できます。
+                        </p>
+                        <p><small>
+                                ※ 設置環境によっては時間要する可能性があります。<br>
+                                ※ 水車発電機の設置のみ。配線や付帯設備工事等は別途。
+                            </small>
+                        </p>
+                    </div>
+                </li>
+                <li class="card_list nf">
+                    <div class="card_img">
+                        <img
+                            src="img/garbage.webp"
+                            alt="低落差対応" />
+                    </div>
+                    <div class="card_content">
+                        <p class="other_title title_left"><span><i class="fa-regular fa-pen-to-square"></i> 異物混入に強い構造</span></p>
+                        <p>
+                            大半の水車は異物混入に弱く、出力低下だけでなく致命的な故障の原因にもなり得ます。
+                        </p>
+                        <p>
+                            パワーアルキメデスはプロペラ状の羽根車を採用しているため、空き缶や落ち葉等の多くは通過して下流に排出されます。塵一つ許さないような精密な管理は必要ありません。
+                        </p>
+                        <p><small>
+                                ※ 故障は発生し難くても、出力低下の要因にはなり得ます。<br>
+                                ※ 万が一に備えて適切な除塵設備は必要です。
+                            </small>
+                        </p>
+                    </div>
+                </li>
+            </ul>
     </section>
 
     <section id="place">
@@ -176,7 +175,7 @@ include 'header.php';
             <p class="cent tx_st">どのような水車にも最適な環境での使用が推奨されています。<br>
                 不適切な環境に設置すると性能低下・機器破損につながるため、最適な使用環境を相談した上で運用する事が推奨されます。</p><br>
 
-            <h3 class="tx_ul"><i class="fa-regular fa-thumbs-up" style="color: #ff643d;"></i> 設置に適している場所 <i class="fa-regular fa-thumbs-up" style="color: #ff643d;"></i></h3>
+            <h3 class="tx_ul cent"><i class="fa-regular fa-thumbs-up" style="color: #ff643d;"></i> 設置に適している場所 <i class="fa-regular fa-thumbs-up" style="color: #ff643d;"></i></h3>
             <ul class="card_items">
                 <li class="card_list nf">
                     <div class="card_img">

--- a/httpdocs/crutto.php
+++ b/httpdocs/crutto.php
@@ -41,7 +41,7 @@ include 'header.php';
                 </div>
             </div>
             <div class="img_text_list">
-                <div class="space_del">
+                <div class="img_list ar_tl">
                     <img
                         src="img/crutto_status.webp"
                         alt="crutto全景" />
@@ -103,60 +103,60 @@ include 'header.php';
                     </table>
                 </div>
 
-                <ul class="card_items">
-                    <li class="card_list nf">
-                        <div class="card_img">
-                            <img
-                                src="img/compar_hydro.webp"
-                                alt="省スペース化" />
-                        </div>
-                        <div class="card_content">
-                            <p class="other_title title_left"><span><i class="fa-regular fa-pen-to-square"></i> 徹底的な省スペース化を実現</span></p>
-                            <p>
-                                Cruttoは既設配管にも接続できるよう、徹底的な省スペース化を追求。家電クラスの小型化を実現しました。
-                            </p>
-                            <p>
-                                重量も30~50kgと男性二人いれば持ち上げられるため、施設内で人力運搬も可能です。
-                            </p>
-                        </div>
-                    </li>
-                    <li class="card_list nf">
-                        <div class="card_img">
-                            <img
-                                src="img/low_cost.webp"
-                                alt="ローコストで設置" />
-                        </div>
-                        <div class="card_content">
-                            <p class="other_title title_left"><span><i class="fa-regular fa-pen-to-square"></i> ローコストで設置</span></p>
-                            <p>
-                                既存設備を最大限活かせる事で工事費も削減。これまでの水力発電と比べて導入のハードルがぐんと下がりました。
-                            </p>
-                            <p>
-                                低コストでも安全性はしっかり確保。数々の検証を経て、落差60m相当の水圧にも対応できる高い耐久性を持ち合わせています。
-                            </p>
-                            <p><small>
-                                    ※ 設置環境によっては対応コストを要する可能性があります。<br>
-                                    ※ 水車発電機の設置のみ。配線や付帯設備工事等は別途。
-                                </small>
-                            </p>
-                        </div>
-                    </li>
-                    <li class="card_list nf">
-                        <div class="card_img">
-                            <img
-                                src="img/100-200v.webp"
-                                alt="100・200V対応" />
-                        </div>
-                        <div class="card_content">
-                            <p class="other_title title_left"><span><i class="fa-regular fa-pen-to-square"></i> 100V・200V選択可能</span></p>
-                            <p>
-                                電源仕様を100Vか200Vで選択できます。<br>
-                                100Vで日常的な電源として、200Vで動力使用や売電を視野に入れる事ができます。
-                            </p>
-                        </div>
-                    </li>
-                </ul>
             </div>
+            <ul class="card_items">
+                <li class="card_list nf">
+                    <div class="card_img">
+                        <img
+                            src="img/compar_hydro.webp"
+                            alt="省スペース化" />
+                    </div>
+                    <div class="card_content">
+                        <p class="other_title title_left"><span><i class="fa-regular fa-pen-to-square"></i> 徹底的な省スペース化を実現</span></p>
+                        <p>
+                            Cruttoは既設配管にも接続できるよう、徹底的な省スペース化を追求。家電クラスの小型化を実現しました。
+                        </p>
+                        <p>
+                            重量も30~50kgと男性二人いれば持ち上げられるため、施設内で人力運搬も可能です。
+                        </p>
+                    </div>
+                </li>
+                <li class="card_list nf">
+                    <div class="card_img">
+                        <img
+                            src="img/low_cost.webp"
+                            alt="ローコストで設置" />
+                    </div>
+                    <div class="card_content">
+                        <p class="other_title title_left"><span><i class="fa-regular fa-pen-to-square"></i> ローコストで設置</span></p>
+                        <p>
+                            既存設備を最大限活かせる事で工事費も削減。これまでの水力発電と比べて導入のハードルがぐんと下がりました。
+                        </p>
+                        <p>
+                            低コストでも安全性はしっかり確保。数々の検証を経て、落差60m相当の水圧にも対応できる高い耐久性を持ち合わせています。
+                        </p>
+                        <p><small>
+                                ※ 設置環境によっては対応コストを要する可能性があります。<br>
+                                ※ 水車発電機の設置のみ。配線や付帯設備工事等は別途。
+                            </small>
+                        </p>
+                    </div>
+                </li>
+                <li class="card_list nf">
+                    <div class="card_img">
+                        <img
+                            src="img/100-200v.webp"
+                            alt="100・200V対応" />
+                    </div>
+                    <div class="card_content">
+                        <p class="other_title title_left"><span><i class="fa-regular fa-pen-to-square"></i> 100V・200V選択可能</span></p>
+                        <p>
+                            電源仕様を100Vか200Vで選択できます。<br>
+                            100Vで日常的な電源として、200Vで動力使用や売電を視野に入れる事ができます。
+                        </p>
+                    </div>
+                </li>
+            </ul>
     </section>
 
     <section id="place">
@@ -170,7 +170,7 @@ include 'header.php';
             <p class="cent tx_st">設置の難易度が低い製品ではあるものの、闇雲に設置しても高い効果は得られません。<br>
                 不適切な環境に設置すると性能低下・機器破損につながるため、最適な使用環境を相談した上で運用する事が推奨されます。</p><br>
 
-            <h3 class="tx_ul"><i class="fa-regular fa-thumbs-up" style="color: #ff643d;"></i> 設置に適している場所 <i class="fa-regular fa-thumbs-up" style="color: #ff643d;"></i></h3>
+            <h3 class="tx_ul cent"><i class="fa-regular fa-thumbs-up" style="color: #ff643d;"></i> 設置に適している場所 <i class="fa-regular fa-thumbs-up" style="color: #ff643d;"></i></h3>
             <ul class="card_items">
                 <li class="card_list nf">
                     <div class="card_img">

--- a/httpdocs/css/style.css
+++ b/httpdocs/css/style.css
@@ -106,7 +106,69 @@ main {
         }
 
         .ar_wd {
-            aspect-ratio: 16/6 !important;
+            aspect-ratio: 16 / 6 !important;
+        }
+
+        .ar_tl {
+            aspect-ratio: 4 / 3;
+        }
+
+        table {
+            width: 100%;
+            border-top: 1px solid #ccc;
+            margin: 1rem 0;
+
+            tbody {
+                tr {
+                    th,
+                    td {
+                        padding: 0.6rem;
+                        text-align: right;
+                        font-size: 1rem;
+                        border-bottom: 1px solid #999;
+                    }
+                    th {
+                        width: 30%;
+                        text-align: left;
+                    }
+                    td {
+                        width: 70%;
+                    }
+                }
+            }
+        }
+
+        .advantage_table {
+            border-top: none;
+            width: auto;
+            margin: 1rem auto;
+            border-collapse: collapse;
+            thead {
+                tr {
+                    th {
+                        padding: 0.6rem;
+                        font-size: 1rem;
+                        font-weight: bold;
+                        border-bottom: 2px dashed #999;
+                        text-align: center;
+                    }
+                }
+            }
+
+            tbody {
+                tr {
+                    td {
+                        padding: 0.5rem;
+                        text-align: center;
+                        font-size: 0.9rem;
+                        border-bottom: 2px dashed #999;
+                    }
+                }
+            }
+
+            tbody tr:last-child td {
+                border-bottom: none; /* 最後の要素は下線を削除 */
+            }
         }
 
         dl {
@@ -159,10 +221,13 @@ main {
                 }
             }
 
-            .space_del {
-                width: 45vw;
-                aspect-ratio: 4 / 3;
-                overflow: hidden;
+            .img_list {
+                place-self: center;
+                margin: 1rem;
+                h3 {
+                    text-align: center;
+                    margin: 0.5rem;
+                }
                 img {
                     width: 100%;
                     height: 100%;
@@ -170,50 +235,18 @@ main {
                     object-position: center; /* 中央から表示（上下の余白が均等に除去される）*/
                 }
             }
-
-            .img_list {
-                width: 50vw;
-                margin: 1rem;
-                h3 {
-                    text-align: center;
-                    margin: 0.5rem;
-                }
-            }
         }
 
         .spec_table {
-            width: 40vw;
-            max-width: 800px;
-            margin: 1rem;
+            padding: 1rem;
+            place-self: center;
+            width: 100%;
+            max-width: 550px;
             p {
                 margin-top: 0.8rem;
                 text-align: center;
                 text-decoration: underline;
                 line-height: 1.8rem;
-            }
-
-            table {
-                width: 100%;
-                border-top: 1px solid #ccc;
-
-                tbody {
-                    tr {
-                        th,
-                        td {
-                            padding: 0.6rem;
-                            text-align: right;
-                            font-size: 1rem;
-                            border-bottom: 1px solid #999;
-                        }
-                        th {
-                            width: 30%;
-                            text-align: left;
-                        }
-                        td {
-                            width: 70%;
-                        }
-                    }
-                }
             }
         }
 
@@ -323,7 +356,6 @@ main {
                 box-shadow: none;
                 background-color: initial;
                 min-height: 0;
-                justify-content: center;
                 transition: none;
                 padding: 0.5rem;
                 img {
@@ -370,35 +402,7 @@ main {
                 max-height: 0;
                 transition: max-height 0.8s ease, padding 0.8s ease;
                 padding: 0 0.5rem;
-
-                table {
-                    width: 100%;
-                    border-collapse: collapse;
-                    margin: 1rem 0;
-
-                    tr {
-                        th,
-                        td {
-                            padding: 0.6rem;
-                            text-align: right;
-                            font-size: 1rem;
-                            border-bottom: 1px solid #999;
-                        }
-                        th {
-                            width: 40%;
-                            text-align: left;
-                        }
-                        td {
-                            width: 60%;
-                        }
-                    }
-                }
             }
-        }
-
-        .fl_cl {
-            display: flex;
-            flex-direction: column;
         }
 
         .row_items {
@@ -517,20 +521,6 @@ main {
                 }
             }
 
-            .img_text_list {
-                .img_list {
-                    width: 90%;
-                    margin: 0 auto;
-                }
-                .space_del {
-                    width: 70vw;
-                }
-            }
-
-            .spec_table {
-                width: 70%;
-            }
-
             .row_items {
                 .row_list {
                     align-items: start;
@@ -636,16 +626,6 @@ main {
                             font-size: 0.9rem;
                         }
                     }
-                }
-            }
-
-            .img_text_list {
-                .space_del {
-                    width: 80vw;
-                }
-
-                .spec_table {
-                    width: 90%;
                 }
             }
 
@@ -1039,7 +1019,7 @@ footer {
 }
 
 .hero_svh {
-    min-height: calc(70vh - 100px);
+    min-height: calc(70dvh - 100px);
     height: auto;
     .hero_bg {
         grid-row: 4 / 5;
@@ -1368,6 +1348,7 @@ footer {
                 gap: 1rem;
                 width: 100%;
                 padding: 1rem;
+                place-self: center;
                 #map {
                     height: 50vh;
                     min-height: 400px;
@@ -1389,16 +1370,6 @@ footer {
                 }
             }
         }
-
-        @media screen and (max-width: 425px) {
-            .img_text_list {
-                .text_list,
-                .map_container {
-                    width: 90%;
-                    margin: 0 auto;
-                }
-            }
-        }
     }
 }
 
@@ -1414,39 +1385,6 @@ footer {
 
 #water_flow {
     background-color: white;
-}
-
-.advantage_table {
-    width: 100%;
-    max-width: 500px;
-    margin: 1rem auto;
-    border-collapse: collapse;
-    thead {
-        tr {
-            th {
-                padding: 0.6rem;
-                font-size: 1rem;
-                font-weight: bold;
-                border-bottom: 2px dashed #999;
-                text-align: center;
-            }
-        }
-    }
-
-    tbody {
-        tr {
-            td {
-                padding: 0.5rem;
-                text-align: center;
-                font-size: 0.9rem;
-                border-bottom: 2px dashed #999;
-            }
-        }
-    }
-
-    tbody tr:last-child td {
-        border-bottom: none; /* 最後の要素は下線を削除 */
-    }
 }
 
 /* acrページ */

--- a/httpdocs/micro.php
+++ b/httpdocs/micro.php
@@ -35,7 +35,7 @@ include 'header.php';
                 </div>
             </div>
             <div class="img_text_list">
-                <div class="text_list wd_sm">
+                <div class="text_list">
                     <p>明確な規定はありませんが、主に100kW未満の水力発電を業界内では『マイクロ』と呼称しています。</p>
 
                     <p>


### PR DESCRIPTION
画像とテキストの組み合わせ部分にgridレイアウト適用。
ただし、太陽光の導入部分だけ構造が異なるので一旦切り分け。

実際にはgrid-templeteの設定次第で調整利きそうではあるが、それはtailwindの時にでも再考。

太陽光で溢れた上記部分を修正。