### PR TITLE
grid style apply to solar img text and card list fixed

### DIFF
--- a/httpdocs/about.php
+++ b/httpdocs/about.php
@@ -70,7 +70,7 @@ include 'header.php';
                     <script type="module" src="/js/main.js"></script>
                     <p>
                         箱根登山バス・小田急箱根高速バス「仙石原文化センター前」　徒歩1分<br /><br />
-                        <span>※ お車でお越しの場合</span><br />
+                        <span>※ お車でお越しの場合</span>
                         建物敷地の駐車場は先着順となっております（予約不可）。<br />
                         駐車できない場合はご相談ください。
                     </p>

--- a/httpdocs/css/style.css
+++ b/httpdocs/css/style.css
@@ -52,6 +52,10 @@ main {
             text-align: center;
         }
 
+        .content_cent {
+            margin: 0 auto;
+        }
+
         .tt_space {
             margin: 1rem 0;
         }
@@ -209,12 +213,11 @@ main {
                 gap: 1rem;
                 width: 100%;
                 padding: 1rem;
+                margin: 0.5rem 0;
 
-                p,
-                ul {
-                    margin: 0.5rem 0 1.5rem 0;
+                p {
+                    max-width: 600px;
                 }
-
                 ul {
                     list-style: disc;
                     padding-left: 1.5rem;
@@ -235,6 +238,10 @@ main {
                     object-position: center; /* 中央から表示（上下の余白が均等に除去される）*/
                 }
             }
+        }
+
+        .grid_1fr {
+            grid-template-columns: 1fr;
         }
 
         .spec_table {

--- a/httpdocs/micro.php
+++ b/httpdocs/micro.php
@@ -36,9 +36,9 @@ include 'header.php';
             </div>
             <div class="img_text_list">
                 <div class="text_list">
-                    <p>明確な規定はありませんが、主に100kW未満の水力発電を業界内では『マイクロ』と呼称しています。</p>
+                    <p class="content_cent">明確な規定はありませんが、主に100kW未満の水力発電を業界内では『マイクロ』と呼称しています。</p>
 
-                    <p>
+                    <p class="content_cent">
                         発電設備の規模とkW単価は反比例の傾向があるため、数100・数1000kW規模の発電所に比べて建設単価が割高になりがちですが、未利用水を有効活用でき脱炭素にも貢献できるため普及が期待されています。
                     </p>
                     <table class="advantage_table">

--- a/httpdocs/solar.php
+++ b/httpdocs/solar.php
@@ -34,9 +34,9 @@ include 'header.php';
                     <h2>太陽光発電の現状</h2>
                 </div>
             </div>
-            <div class="img_text_list">
-                <div class="text_list wd_lg">
-                    <p>
+            <div class="img_text_list grid_1fr">
+                <div class="text_list">
+                    <p class="content_cent">
                         これまでの太陽光発電は、発電量を追求した売電事業が盛んでしたが、FIT（固定価格買取制度）の買取価格低下及び電気代の高騰により、作った電気を『売る』時代から『使う』時代に移行しています。
                     </p>
                     <ul class="card_items">
@@ -47,11 +47,9 @@ include 'header.php';
                                     src="img/old_solar.webp"
                                     alt="これまでの太陽光発電" />
                             </div>
-                            <div class="card_content">
-                                <p class="cent tx_st">
-                                    FIT主体（野建・広域・高出力）
-                                </p>
-                            </div>
+                            <p class="cent tx_st">
+                                FIT主体（野建・広域・高出力）
+                            </p>
                         </li>
                         <li class="card_list">
                             <h3 class="cent no_dc tx_ul">現在の太陽光発電</h3>
@@ -60,11 +58,9 @@ include 'header.php';
                                     src="img/now_solar.webp"
                                     alt="現在の太陽光発電" />
                             </div>
-                            <div class="card_content">
-                                <p class="cent tx_st">
-                                    自家消費・蓄電主体（屋根置・需要ベース）
-                                </p>
-                            </div>
+                            <p class="cent tx_st">
+                                自家消費・蓄電主体（屋根置・需要ベース）
+                            </p>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
ブランチ作成順番をミスったため少し履歴乱れるかも。

太陽光に合わせてgridレイアウト修正。
・新たに1fr用のクラス作成して太陽光に適用。
・カードリストにもう少し柔軟性持たせるためにautoと1frの適用箇所を変更。

フロー部分にgrid適用