### PR TITLE
card items max-width and img overflow delete

### DIFF
--- a/httpdocs/css/style.css
+++ b/httpdocs/css/style.css
@@ -96,10 +96,6 @@ main {
             background-color: #f1f0f0;
         }
 
-        .wd_lg {
-            width: 70vw;
-        }
-
         .no_dc {
             background-color: initial;
             border: none;
@@ -302,17 +298,11 @@ main {
 
         .card_items {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
             align-items: stretch; /* 高さ揃え */
-            gap: 2.5rem;
-            max-width: 1250px; /* 全体の幅制限 */
+            gap: 2rem;
             margin: 0 auto;
             padding: 2rem 1rem;
-
-            @media screen and (max-width: 610px) {
-                grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-                max-width: 600px;
-            }
 
             .card_list {
                 display: grid;
@@ -323,21 +313,19 @@ main {
                 box-shadow: 3px 3px 8px rgba(100, 100, 100, 0.3);
                 transition: box-shadow 0.3s ease;
                 min-width: 0;
-                max-width: 500px;
                 width: 100%;
-                @media screen and (max-width: 768px) {
-                    max-width: 400px;
-                }
 
                 .card_img {
                     aspect-ratio: 16 / 10;
-                    overflow: hidden;
+                    /* overflow: hidden; */
+                    width: 100%;
                     img {
                         width: 100%;
                         height: 100%;
                         object-fit: cover;
                         object-position: center;
                         display: block;
+                        overflow: hidden;
                     }
                 }
 


### PR DESCRIPTION
折り返しが上手くいかない理由を探ったがイマイチ判然としない。

- card_itemsのmax-widthを消すと折り返しが上手くいく
　ただし、子要素は画面幅いっぱいに広がってしまう or card_listから孫要素がはみ出る...imgをサイズ指定しても解決できない

- card_imgのoverflow:hiddenを消すとcard_listの不自然な重なりは解消できる。
　card_contentがあると不自然な重なりは発生しないが、ないとcard_listが重なるなどの挙動がある。

たぶん、grid-template-columnsのminmax設定とその他が上手く消化できていないのだが、
現時点ではわからないので425pxブレークポイントを優先する。