### PR TITLE
tailwindcss setting to bread crumbs

### DIFF
--- a/httpdocs/about.php
+++ b/httpdocs/about.php
@@ -16,20 +16,13 @@ include 'header.php';
     </div>
 </section>
 
-<section id="bread_crumb">
-    <nav aria-label="breadcrumb">
-        <ol class="bread_crumb_list">
-            <li class="bread_crumb_item">
-                <a href="/">
-                    <i class="fa-solid fa-house"></i> ホーム
-                </a>
-            </li>
-            <li class="bread_crumb_item active" aria-current="page">
-                会社概要
-            </li>
-        </ol>
-    </nav>
-</section>
+<?php
+$breadcrumbs = [
+    ['url' => '/',               'label' => 'ホーム'],
+    ['url' => 'about.php',       'label' => '会社概要', 'active' => true],
+];
+include 'bread.php';
+?>
 
 <main>
     <section id="about_company">

--- a/httpdocs/arc.php
+++ b/httpdocs/arc.php
@@ -16,25 +16,14 @@ include 'header.php';
     </div>
 </section>
 
-<section id="bread_crumb">
-    <nav aria-label="breadcrumb">
-        <ol class="bread_crumb_list">
-            <li class="bread_crumb_item">
-                <a href="/">
-                    <i class="fa-solid fa-house"></i> ホーム
-                </a>
-            </li>
-            <li class="bread_crumb_item">
-                <a href="micro.php">
-                    マイクロ水力発電
-                </a>
-            </li>
-            <li class="bread_crumb_item active" aria-current="page">
-                パワーアルキメデス
-            </li>
-        </ol>
-    </nav>
-</section>
+<?php
+$breadcrumbs = [
+    ['url' => '/',               'label' => 'ホーム'],
+    ['url' => 'micro.php',       'label' => 'マイクロ水力発電'],
+    ['url' => 'arc.php',         'label' => 'パワーアルキメデス', 'active' => true],
+];
+include 'bread.php';
+?>
 
 <main>
     <section id="about_arc" class="py-8">

--- a/httpdocs/bread.php
+++ b/httpdocs/bread.php
@@ -1,0 +1,28 @@
+<section id="bread_crumb" class="bg-white px-4 py-2">
+    <nav aria-label="breadcrumb">
+        <ol class="grid grid-flow-col gap-2 text-sm w-fit min-w-0 list-none p-0 m-0">
+            <?php foreach ($breadcrumbs as $crumb): ?>
+                <li class="grid grid-flow-col items-center gap-1
+            <?php echo empty($crumb['active'])
+                    ? 'text-blue-600 hover:underline'
+                    : 'text-gray-600 font-bold'; ?>
+            after:content-['>'] after:ml-2 after:text-gray-300 last:after:content-none"
+                    <?php if (!empty($crumb['active'])) echo 'aria-current="page"'; ?>>
+                    <?php if (empty($crumb['active'])): ?>
+                        <a href="<?php echo $crumb['url']; ?>" class="grid grid-flow-col items-center gap-1">
+                            <?php if ($crumb['url'] === '/'): // ホームのときだけアイコンを表示 
+                            ?>
+                                <i class="fa-solid fa-house" aria-hidden="true"></i>
+                            <?php endif; ?>
+                            <span><?php echo $crumb['label']; ?></span>
+                        </a>
+                    <?php else: ?>
+                        <?php // アクティブ（リンクなし）のときもアイコンを入れたいなら同様に 
+                        ?>
+                        <?php echo $crumb['label']; ?>
+                    <?php endif; ?>
+                </li>
+            <?php endforeach; ?>
+        </ol>
+    </nav>
+</section>

--- a/httpdocs/crutto.php
+++ b/httpdocs/crutto.php
@@ -16,25 +16,14 @@ include 'header.php';
     </div>
 </section>
 
-<section id="bread_crumb">
-    <nav aria-label="breadcrumb">
-        <ol class="bread_crumb_list">
-            <li class="bread_crumb_item">
-                <a href="/">
-                    <i class="fa-solid fa-house"></i> ホーム
-                </a>
-            </li>
-            <li class="bread_crumb_item">
-                <a href="micro.php">
-                    マイクロ水力発電
-                </a>
-            </li>
-            <li class="bread_crumb_item active" aria-current="page">
-                Crutto
-            </li>
-        </ol>
-    </nav>
-</section>
+<?php
+$breadcrumbs = [
+    ['url' => '/',               'label' => 'ホーム'],
+    ['url' => 'micro.php',       'label' => 'マイクロ水力発電'],
+    ['url' => 'crutto.php',      'label' => 'Crutto', 'active' => true],
+];
+include 'bread.php';
+?>
 
 <main>
     <section id="about_crutto" class="py-8">

--- a/httpdocs/css/style.css
+++ b/httpdocs/css/style.css
@@ -594,65 +594,6 @@ main {
     }
 }
 
-/* News要素 */
-#news {
-    .container {
-        .time_items {
-            display: grid;
-            padding: 0 1rem;
-            margin: 1rem auto;
-            max-height: 300px;
-            max-width: 600px;
-            overflow: auto;
-            border-top: 2px solid #aaaaaa;
-            border-bottom: 2px solid #aaaaaa;
-
-            @media screen and (max-width: 768px) {
-                max-width: 400px;
-            }
-
-            @media screen and (max-width: 425px) {
-                max-width: 300px;
-            }
-        }
-
-        .time_list {
-            display: grid;
-            grid-template-columns: 120px 1fr;
-            gap: 1rem;
-            align-items: center;
-            padding: 1rem 0;
-            border-bottom: 1px solid #ddd;
-
-            @media screen and (max-width: 768px) {
-                grid-template-columns: 1fr;
-                padding-bottom: 1rem;
-            }
-        }
-        .time_list:last-child {
-            border-bottom: none;
-        }
-
-        time {
-            font-weight: bold;
-            @media screen and (max-width: 768px) {
-                width: 100%;
-                margin-bottom: 0.5rem;
-            }
-        }
-
-        .time_title {
-            a {
-                color: #005eff;
-                text-decoration: underline;
-            }
-            @media screen and (max-width: 768px) {
-                width: 100%;
-            }
-        }
-    }
-}
-
 /* company要素 */
 #company {
     min-height: 60vh;
@@ -831,51 +772,6 @@ main {
         @media screen and (max-width: 480px) {
             font-size: 0.95rem;
         }
-    }
-}
-
-/* bread_crumb要素 */
-#bread_crumb {
-    background-color: white;
-    padding: 0.5rem 1rem;
-}
-
-.bread_crumb_list {
-    display: grid;
-    grid-auto-flow: column;
-    gap: 0.5rem;
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    font-size: 0.9rem;
-    width: fit-content;
-    min-width: 0;
-}
-
-.bread_crumb_item {
-    display: grid;
-    grid-auto-flow: column;
-    align-items: center;
-    gap: 0.3rem;
-
-    a {
-        text-decoration: none;
-        color: #007bff;
-    }
-
-    &.active {
-        color: #555;
-        font-weight: bold;
-    }
-
-    &::after {
-        content: ">";
-        color: #ccc;
-        margin-left: 0.5rem;
-    }
-
-    &:last-child::after {
-        content: none;
     }
 }
 

--- a/httpdocs/micro.php
+++ b/httpdocs/micro.php
@@ -15,20 +15,13 @@ include 'header.php';
     </div>
 </section>
 
-<section id="bread_crumb">
-    <nav aria-label="breadcrumb">
-        <ol class="bread_crumb_list">
-            <li class="bread_crumb_item">
-                <a href="/">
-                    <i class="fa-solid fa-house"></i> ホーム
-                </a>
-            </li>
-            <li class="bread_crumb_item active" aria-current="page">
-                マイクロ水力発電
-            </li>
-        </ol>
-    </nav>
-</section>
+<?php
+$breadcrumbs = [
+    ['url' => '/',               'label' => 'ホーム'],
+    ['url' => 'micro.php',       'label' => 'マイクロ水力発電', 'active' => true],
+];
+include 'bread.php';
+?>
 
 <main>
     <section id="about_micro" class="py-8">

--- a/httpdocs/solar.php
+++ b/httpdocs/solar.php
@@ -15,20 +15,13 @@ include 'header.php';
     </div>
 </section>
 
-<section id="bread_crumb">
-    <nav aria-label="breadcrumb">
-        <ol class="bread_crumb_list">
-            <li class="bread_crumb_item">
-                <a href="/">
-                    <i class="fa-solid fa-house"></i> ホーム
-                </a>
-            </li>
-            <li class="bread_crumb_item active" aria-current="page">
-                太陽光発電・蓄電システム
-            </li>
-        </ol>
-    </nav>
-</section>
+<?php
+$breadcrumbs = [
+    ['url' => '/',               'label' => 'ホーム'],
+    ['url' => 'solar.php',       'label' => '太陽光発電・蓄電システム', 'active' => true],
+];
+include 'bread.php';
+?>
 
 <main>
     <section id="about_solar" class="py-8">


### PR DESCRIPTION
パンくずリストにtailwindcss適用。
パンくずリストも共通化していちいち全部書き直すスタイルはやめ。

indexの構成要素から順にtailwindcss化。