### PR TITLE
tailwindcss settig to accordion items

### DIFF
--- a/httpdocs/arc.php
+++ b/httpdocs/arc.php
@@ -50,7 +50,7 @@ include 'bread.php';
                 <div class="grid gap-4 w-full px-4">
                     <h3 class="text-lg font-bold justify-self-center">【基本仕様】</h3>
 
-                    <dl class="w-3/4 lg:w-5/6 max-[510px]:w-full mx-auto border-x-0 border-t border-b border-solid border-gray-500 divide-y divide-gray-300 text-sm spec-table">
+                    <dl class="w-3/4 lg:w-5/6 max-[510px]:w-full mx-auto border-x-0 border-t border-b border-solid border-gray-500 divide-y divide-gray-300 text-sm col2_list">
                         <!-- 各行を grid で 2 列に -->
                         <div>
                             <dt>水車形式</dt>
@@ -301,122 +301,159 @@ include 'bread.php';
             </ul>
     </section>
 
+    <!-- 導入事例 -->
     <section id="record" class="py-8">
-        <div class="grid justify-center py-8 overflow-hidden">
+        <div class="grid overflow-hidden">
             <div class="grid justify-center my-8 max-[425px]:mt-4">
                 <div class="grid grid-cols-[auto_1fr] items-center gap-4 text-left">
                     <span class="w-3 h-8 bg-gradient-to-b from-blue-400 to-blue-900 -skew-x-[30deg] block"></span>
                     <h2 class="font-bold text-4xl max-[768px]:text-3xl max-[425px]:text-2xl drop-shadow-lg">導入事例</h2>
                 </div>
             </div>
-            <ul class="card_items">
-                <li class="card_list nf">
-                    <button class="accordion_header">長野県安曇野市 宮城小水力発電所</button>
-                    <div class="accordion_content">
-                        <div class="card_img">
-                            <img src="/img/azumino_pic.webp" alt="安曇野宮城小水力発電所" />
+
+            <ul class="grid gap-6 m-4 justify-center md:[grid-template-columns:repeat(auto-fit,400px)]">
+                <li class="overflow-hidden justify-self-center max-w-sm min-w-0 md:max-w-none py-8">
+                    <!-- ヘッダー（ボタン） -->
+                    <button class="accordion_header">
+                        長野県安曇野市 宮城小水力発電所
+                    </button>
+
+                    <!-- 折りたたみコンテンツ -->
+                    <div class="accordion_content bg-inherit">
+                        <div class="accordion_inner px-2 py-4">
+                            <!-- 画像部分 -->
+                            <div class="mb-4 aspect-[16/9]">
+                                <img
+                                    src="/img/azumino_pic.webp"
+                                    alt="安曇野宮城小水力発電所"
+                                    class="w-full h-full object-cover object-center block rounded-xl border border-black" />
+                            </div>
+                            <!-- 説明リスト（共有のdl/dt/dd） -->
+                            <dl class="gap-y-2 text-sm divide-y divide-gray-300 border-t border-b border-solid border-gray-500 col2_list">
+                                <div>
+                                    <dt>使用流量</dt>
+                                    <dd>0.95m³/s</dd>
+                                </div>
+                                <div>
+                                    <dt>有効落差</dt>
+                                    <dd>3.0m</dd>
+                                </div>
+                                <div>
+                                    <dt>最大発電出力</dt>
+                                    <dd>16.9kW</dd>
+                                </div>
+                                <div>
+                                    <dt>発電方式</dt>
+                                    <dd>低落差開放型</dd>
+                                </div>
+                                <div>
+                                    <dt>電力用途</dt>
+                                    <dd>全量売電</dd>
+                                </div>
+                                <div>
+                                    <dt>事業者</dt>
+                                    <dd>有明土地改良区</dd>
+                                </div>
+                            </dl>
                         </div>
-                        <table>
-                            <tr>
-                                <th>使用流量</th>
-                                <td>0.95m³/s</td>
-                            </tr>
-                            <tr>
-                                <th>有効落差</th>
-                                <td>3.0m</td>
-                            </tr>
-                            <tr>
-                                <th>最大発電出力</th>
-                                <td>16.9kW</td>
-                            </tr>
-                            <tr>
-                                <th>発電方式</th>
-                                <td>低落差開放型</td>
-                            </tr>
-                            <tr>
-                                <th>電力用途</th>
-                                <td>全量売電</td>
-                            </tr>
-                            <tr>
-                                <th>事業者</th>
-                                <td>有明土地改良区</td>
-                            </tr>
-                        </table>
                     </div>
                 </li>
-                <li class="card_list nf">
-                    <button class="accordion_header">岩手県花巻市 松沢川小水力発電所</button>
-                    <div class="accordion_content">
-                        <div class="card_img">
-                            <img src="/img/hanamaki.webp" alt="松沢川小水力発電所" />
+
+                <li class="overflow-hidden justify-self-center max-w-sm min-w-0 md:max-w-none py-8">
+                    <!-- ヘッダー（ボタン） -->
+                    <button class="accordion_header">
+                        岩手県花巻市 松沢川小水力発電所
+                    </button>
+
+                    <!-- 折りたたみコンテンツ -->
+                    <div class="accordion_content bg-inherit">
+                        <div class="accordion_inner px-2 py-4">
+                            <!-- 画像部分 -->
+                            <div class="mb-4 aspect-[16/9]">
+                                <img
+                                    src="/img/hanamaki.webp" alt="松沢川小水力発電所"
+                                    class="w-full h-full object-cover object-center block rounded-xl border border-black" />
+                            </div>
+                            <!-- 説明リスト（共有のdl/dt/dd） -->
+                            <dl class="gap-y-2 text-sm divide-y divide-gray-300 border-t border-b border-solid border-gray-500 col2_list">
+                                <div>
+                                    <dt>使用流量</dt>
+                                    <dd>1号機：1.4m³/s<br>
+                                        2号機：0.95m³/s</dd>
+                                </div>
+                                <div>
+                                    <dt>有効落差</dt>
+                                    <dd>4.1m</dd>
+                                </div>
+                                <div>
+                                    <dt>最大発電出力</dt>
+                                    <dd>1号機：33.7kW<br>
+                                        2号機：13.5kW</dd>
+                                </div>
+                                <div>
+                                    <dt>発電方式</dt>
+                                    <dd>低落差開放型</dd>
+                                </div>
+                                <div>
+                                    <dt>電力用途</dt>
+                                    <dd>全量売電</dd>
+                                </div>
+                                <div>
+                                    <dt>事業者</dt>
+                                    <dd>豊沢川土地改良区</dd>
+                                </div>
+                            </dl>
                         </div>
-                        <table>
-                            <tr>
-                                <th>使用流量</th>
-                                <td>1号機：1.4m³/s<br>
-                                    2号機：0.95m³/s
-                                </td>
-                            </tr>
-                            <tr>
-                                <th>有効落差</th>
-                                <td>4.1m</td>
-                            </tr>
-                            <tr>
-                                <th>最大発電出力</th>
-                                <td>1号機：33.7kW<br>
-                                    2号機：13.5kW
-                                </td>
-                            </tr>
-                            <tr>
-                                <th>発電方式</th>
-                                <td>低落差開放型</td>
-                            </tr>
-                            <tr>
-                                <th>電力用途</th>
-                                <td>全量売電</td>
-                            </tr>
-                            <tr>
-                                <th>事業者</th>
-                                <td>豊沢川土地改良区</td>
-                            </tr>
-                        </table>
                     </div>
                 </li>
-                <li class="card_list nf">
-                    <button class="accordion_header">宮崎県えびの市 田代陣の池ホタル谷発電所</button>
-                    <div class="accordion_content">
-                        <div class="card_img">
-                            <img src="/img/Ebino.webp" alt="田代陣の池ホタル谷発電所" />
+
+                <li class="overflow-hidden justify-self-center max-w-sm min-w-0 md:max-w-none py-8">
+                    <!-- ヘッダー（ボタン） -->
+                    <button class="accordion_header">
+                        宮崎県えびの市 田代陣の池ホタル谷発電所
+                    </button>
+
+                    <!-- 折りたたみコンテンツ -->
+                    <div class="accordion_content bg-inherit">
+                        <div class="accordion_inner px-2 py-4">
+                            <!-- 画像部分 -->
+                            <div class="mb-4 aspect-[16/9]">
+                                <img
+                                    src="/img/Ebino.webp" alt="田代陣の池ホタル谷発電所"
+                                    class="w-full h-full object-cover object-center block rounded-xl border border-black" />
+                            </div>
+                            <!-- 説明リスト（共有のdl/dt/dd） -->
+                            <dl class="gap-y-2 text-sm divide-y divide-gray-300 border-t border-b border-solid border-gray-500 col2_list">
+                                <div>
+                                    <dt>使用流量</dt>
+                                    <dd>0.4m³/s</dd>
+                                </div>
+                                <div>
+                                    <dt>有効落差</dt>
+                                    <dd>5.9m</dd>
+                                </div>
+                                <div>
+                                    <dt>最大発電出力</dt>
+                                    <dd>13.9kW</dd>
+                                </div>
+                                <div>
+                                    <dt>発電方式</dt>
+                                    <dd>中落差配管型</dd>
+                                </div>
+                                <div>
+                                    <dt>電力用途</dt>
+                                    <dd>全量売電</dd>
+                                </div>
+                                <div>
+                                    <dt>事業者</dt>
+                                    <dd>えびの市土地改良区</dd>
+                                </div>
+                            </dl>
                         </div>
-                        <table>
-                            <tr>
-                                <th>使用流量</th>
-                                <td>0.4m³/s</td>
-                            </tr>
-                            <tr>
-                                <th>有効落差</th>
-                                <td>5.9m</td>
-                            </tr>
-                            <tr>
-                                <th>最大発電出力</th>
-                                <td>13.9kW</td>
-                            </tr>
-                            <tr>
-                                <th>発電方式</th>
-                                <td>中落差配管型</td>
-                            </tr>
-                            <tr>
-                                <th>電力用途</th>
-                                <td>全量売電</td>
-                            </tr>
-                            <tr>
-                                <th>事業者</th>
-                                <td>えびの市土地改良区</td>
-                            </tr>
-                        </table>
                     </div>
                 </li>
             </ul>
+        </div>
     </section>
 </main>
 

--- a/httpdocs/css/style.css
+++ b/httpdocs/css/style.css
@@ -6,12 +6,6 @@ body {
     background-color: #f4f4f4;
 }
 
-.mw_800 {
-    max-width: 800px;
-    margin: 0 auto;
-    padding: 0.5rem 1.5rem;
-}
-
 main {
     .mask_img {
         -webkit-mask-image: linear-gradient(
@@ -45,24 +39,6 @@ main {
         }
     }
 
-    .other_title {
-        font-size: 1.2rem;
-        font-weight: bold;
-        text-align: center;
-        margin: 0.5rem 0;
-        @media screen and (max-width: 768px) {
-            font-size: 1.1rem;
-        }
-    }
-
-    .cent {
-        text-align: center;
-    }
-
-    .self_cent {
-        place-self: center;
-    }
-
     .tt_space {
         margin: 1rem 0;
     }
@@ -70,10 +46,6 @@ main {
         font-size: 1.1rem;
         font-weight: bold;
         padding: 1.5rem;
-    }
-
-    .tx_ul {
-        text-decoration: underline;
     }
 
     .band_style {
@@ -102,10 +74,6 @@ main {
             border-top: 1px dashed black;
             height: 1px;
         }
-    }
-
-    .ar_tl {
-        aspect-ratio: 4 / 3;
     }
 
     table {
@@ -148,43 +116,6 @@ main {
         @media screen and (max-width: 425px) {
             font-size: 1.5rem;
         }
-    }
-
-    .accordion_header {
-        width: 100%;
-        background-color: #f5f5f5;
-        border: none;
-        text-align: left;
-        padding: 0.5rem 2.1rem 0.5rem 0.5rem;
-        font-weight: bold;
-        font-size: 1rem;
-        cursor: pointer;
-        border-bottom: 2px solid #ccc;
-        position: relative;
-    }
-
-    .accordion_header::after {
-        content: "";
-        width: 16px;
-        height: 16px;
-        background: url("../img/down.svg") no-repeat center center;
-        background-size: contain;
-        position: absolute;
-        top: 50%;
-        right: 0.5rem;
-        transform: translateY(-50%);
-        transition: all 0.3s;
-    }
-
-    .accordion_header.active::after {
-        background: url("../img/Up.svg") no-repeat center center;
-    }
-
-    .accordion_content {
-        overflow: hidden;
-        max-height: 0;
-        transition: max-height 0.8s ease, padding 0.8s ease;
-        padding: 0 0.5rem;
     }
 }
 
@@ -414,8 +345,6 @@ main {
 /* aboutページ */
 
 #about_company {
-    background-color: white;
-
     .map_container {
         display: grid;
         gap: 1rem;
@@ -442,15 +371,6 @@ main {
             }
         }
     }
-}
-
-/* solarページ */
-#about_solar {
-    background-color: white;
-}
-
-#solar_place {
-    background-color: white;
 }
 
 .solar_merit {

--- a/httpdocs/js/main.js
+++ b/httpdocs/js/main.js
@@ -9,22 +9,18 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 });
 
-document.querySelectorAll(".accordion_header").forEach((header) => {
-    header.addEventListener("click", function () {
-        const content = this.nextElementSibling;
+document.querySelectorAll(".accordion_header").forEach((btn) => {
+    btn.addEventListener("click", () => {
+        const content = btn.nextElementSibling; // .accordion_content
+        const inner = content.querySelector(".accordion_inner");
 
-        // 閉じているときだけ開く処理
         if (content.style.maxHeight) {
             content.style.maxHeight = null;
-            content.style.paddingTop = "0";
-            content.style.paddingBottom = "0";
-            this.classList.remove("active");
+            btn.classList.remove("active");
         } else {
-            // 対象だけ開く
-            content.style.maxHeight = content.scrollHeight + "px";
-            content.style.paddingTop = "1rem";
-            content.style.paddingBottom = "1rem";
-            this.classList.add("active");
+            // inner の重さ（padding込みの高さ）を測ってセット
+            content.style.maxHeight = inner.scrollHeight + "px";
+            btn.classList.add("active");
         }
     });
 });
@@ -36,38 +32,3 @@ document.querySelectorAll(".more_btn").forEach((button) => {
         }
     });
 });
-
-// モーダル関連
-function openConfirmDialog() {
-    // 入力内容を取得
-    document.getElementById("confirm_name").textContent =
-        document.getElementById("name").value;
-    document.getElementById("confirm_email").textContent =
-        document.getElementById("email").value;
-    document.getElementById("confirm_organization").textContent =
-        document.getElementById("organization").value;
-    document.getElementById("confirm_tel").textContent =
-        document.getElementById("tel").value;
-    document.getElementById("confirm_detail").textContent =
-        document.getElementById("detail").value;
-
-    // 確認モーダルを表示
-    document.getElementById("confirmDialog").showModal();
-}
-
-function closeConfirmDialog() {
-    document.getElementById("confirmDialog").close();
-}
-
-function submitForm() {
-    // 確認モーダルを閉じる
-    document.getElementById("confirmDialog").close();
-
-    // 送信完了モーダルを表示
-    document.getElementById("successDialog").showModal();
-}
-
-function closeSuccessDialog() {
-    document.getElementById("successDialog").close();
-    document.getElementById("contactForm").reset(); // フォームをリセット
-}

--- a/httpdocs/src/input.css
+++ b/httpdocs/src/input.css
@@ -4,15 +4,37 @@
 
 @layer components {
     /* 各行（grid 2 列） */
-    .spec-table > div {
+    .col2_list > div {
         @apply grid grid-cols-[1fr_2fr] py-2;
     }
     /* 見出し側 */
-    .spec-table dt {
+    .col2_list dt {
         @apply font-semibold text-gray-800 self-center p-2;
     }
     /* 定義側 */
-    .spec-table dd {
+    .col2_list dd {
         @apply text-right p-2;
+    }
+
+    /* アコーディオンのヘッダー部分 */
+    .accordion_header {
+        @apply relative w-full text-left font-bold text-base
+        pl-2 pr-8 py-2 border-b-2 border-gray-300 cursor-pointer
+        focus:outline-none focus:ring-2 focus:ring-blue-400
+        transition-colors duration-200;
+    }
+    .accordion_header::after {
+        content: "";
+        @apply absolute right-2 top-1/2 w-4 h-4 bg-no-repeat bg-center bg-contain
+        transition-transform duration-300 -translate-y-1/2;
+        background-image: url("../img/down.svg");
+    }
+    .accordion_header.active::after {
+        background-image: url("../img/Up.svg");
+    }
+
+    /* アコーディオンの中身部分 */
+    .accordion_content {
+        @apply overflow-hidden max-h-0 px-2 transition-[max-height] duration-700 ease-in-out;
     }
 }

--- a/httpdocs/tailwind.config.js
+++ b/httpdocs/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-    content: ["./**/*.{php,html}"],
+    content: ["./**/*.{php,html}", "./js/**/*.js"],
     theme: {
         extend: {},
     },


### PR DESCRIPTION
アコーディオン部分にtailwind適用。

css上の変化＋javascriptも調整。
- アコーディオン開閉時にpaddingの読み込みタイミングが意図したものにならず、maxHeight確定後にpaddingが入って要素がはみ出してしまう。
- paddingは予め専用のdivを設けておき、divの中身だけmaxHeightとして計算する。
- activeクラスはあってもなくても開閉に関係ないが、svg画像の入れ替えトリガーと、何らかの目印として残しておく。

次はmap関連にtailwind適用