### PR TITLE
top btn not implement, google analytics tag set

### DIFF
--- a/httpdocs/header.php
+++ b/httpdocs/header.php
@@ -2,6 +2,19 @@
 <html lang="ja">
 
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-P6XVD5NGZW"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+
+        function gtag() {
+            dataLayer.push(arguments);
+        }
+        gtag('js', new Date());
+
+        gtag('config', 'G-P6XVD5NGZW');
+    </script>
+
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title><?php echo isset($page_title) ? $page_title : "CEM"; ?></title>


### PR DESCRIPTION
トップへ戻るボタンは未実装。

- そもそもAndroid以外の端末には上部へ戻る機能がある（初耳）。
- 右下にはチャットボットが設置される時代。UI上邪魔なだけ。
- 上に戻す暇があるなら有益なページに誘導すべき

「確かに」と言える要素が大半だったのでやめた。
折角なのでGoogle Analyticsのタグだけ設置しておいた。

一通り完了した。
画像分解とファビコン作成する作業が残っているが、手間の割に大した効果なさそうなので後回し。
しばらくはReact・Next.jsで色々制作する修練に励む。