### PR TITLE
index about image and text z-index change

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.8'
 services:
   php:
     build: .
+    image: hp_remake_php:latest
     ports:
       - "8080:80"
     volumes:

--- a/httpdocs/header.php
+++ b/httpdocs/header.php
@@ -33,6 +33,8 @@
             scroll-behavior: smooth;
         }
     </style>
+
+
 </head>
 
 <body>

--- a/httpdocs/hero.php
+++ b/httpdocs/hero.php
@@ -17,7 +17,8 @@ $hero_sub_h3_cls   = $hero_sub_h3_cls   ?? '';
 ?>
 <section
     id="<?php echo htmlspecialchars($hero_id, ENT_QUOTES); ?>"
-    class="<?php echo $hero_classes; ?> bg-[url('<?php echo htmlspecialchars($hero_bg, ENT_QUOTES); ?>')]">
+    class="<?php echo $hero_classes; ?> "
+    style="background-image: url('<?php echo htmlspecialchars($hero_bg, ENT_QUOTES); ?>');">
     <div class="<?php echo htmlspecialchars($hero_div_cls, ENT_QUOTES); ?>">
         <h2 class="<?php echo htmlspecialchars($hero_h2, ENT_QUOTES); ?>">
             <?php echo htmlspecialchars($hero_title, ENT_QUOTES); ?>

--- a/httpdocs/index.php
+++ b/httpdocs/index.php
@@ -76,9 +76,9 @@ include 'hero.php';
     <section id="company" class="py-8">
         <div class="grid overflow-hidden">
             <ul class="grid grid-cols-1">
-                <li class="grid md:grid-cols-[2fr_1fr] grid-cols-1 ">
+                <li class="relative grid md:grid-cols-[2fr_1fr] grid-cols-1 ">
                     <!-- 画像部分 -->
-                    <div class="grid max-h-96 overflow-hidden col-start-1 row-start-1 w-full h-full">
+                    <div class="z-0 grid max-h-96 overflow-hidden col-start-1 row-start-1 w-full h-full">
                         <img
                             src="/img/company_front.webp"
                             alt="会社案内"
@@ -86,7 +86,7 @@ include 'hero.php';
                     </div>
                     <!-- テキスト部分 -->
                     <div
-                        class="grid grid-rows-[auto_1fr_auto] p-4 place-items-center place-self-center gap-6 col-start-1 row-start-1 md:col-start-auto max-w-[65%] md:max-w-full">
+                        class="z-10 grid grid-rows-[auto_1fr_auto] p-4 place-items-center place-self-center gap-6 col-start-1 row-start-1 md:col-start-auto max-w-[65%] md:max-w-full">
                         <!-- タイトル -->
                         <div class="grid justify-center my-4 md:mt-4">
                             <div class="grid grid-cols-[auto_1fr] items-center gap-3 text-left">
@@ -106,7 +106,7 @@ include 'hero.php';
                             href="about.php"
                             role="button"
                             tabindex="0"
-                            class="block w-36 md:w-40 px-4 py-2 text-center rounded-full font-bold bg-[#2e4488] hover:bg-sky-400 text-white shadow-md hover:shadow-lg transition-colors duration-300 ease-in-out max-[425px]:text-[0.8rem]">
+                            class="block w-36 md:w-40 px-4 py-2 text-center rounded-full align-self-end justify-self-center font-bold bg-[#2e4488] hover:bg-sky-400 text-white shadow-md hover:shadow-lg transition-colors duration-300 ease-in-out max-[425px]:text-[0.8rem]">
                             もっと見る
                         </a>
                     </div>

--- a/httpdocs/public/output.css
+++ b/httpdocs/public/output.css
@@ -625,8 +625,8 @@ video {
 
 @media (min-width: 768px) {
   .design_table {
-    font-size: 1rem;
-    line-height: 1.5rem;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
   }
 }
 
@@ -739,6 +739,10 @@ video {
   top: -1rem;
 }
 
+.right-2 {
+  right: 0.5rem;
+}
+
 .right-4 {
   right: 1rem;
 }
@@ -751,6 +755,10 @@ video {
   top: 0px;
 }
 
+.top-1\/2 {
+  top: 50%;
+}
+
 .top-8 {
   top: 2rem;
 }
@@ -761,6 +769,14 @@ video {
 
 .top-\[49px\] {
   top: 49px;
+}
+
+.z-0 {
+  z-index: 0;
+}
+
+.z-10 {
+  z-index: 10;
 }
 
 .z-20 {
@@ -813,10 +829,6 @@ video {
 
 .row-end-7 {
   grid-row-end: 7;
-}
-
-.row-end-4 {
-  grid-row-end: 4;
 }
 
 .m-0 {
@@ -942,6 +954,10 @@ video {
   height: 2.5rem;
 }
 
+.h-4 {
+  height: 1rem;
+}
+
 .h-8 {
   height: 2rem;
 }
@@ -970,8 +986,8 @@ video {
   height: 100vh;
 }
 
-.h-80 {
-  height: 20rem;
+.max-h-0 {
+  max-height: 0px;
 }
 
 .max-h-72 {
@@ -980,10 +996,6 @@ video {
 
 .max-h-96 {
   max-height: 24rem;
-}
-
-.max-h-\[70vh\] {
-  max-height: 70vh;
 }
 
 .min-h-\[300px\] {
@@ -1008,6 +1020,10 @@ video {
 
 .w-36 {
   width: 9rem;
+}
+
+.w-4 {
+  width: 1rem;
 }
 
 .w-4\/5 {
@@ -1093,6 +1109,10 @@ video {
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
+.cursor-pointer {
+  cursor: pointer;
+}
+
 .scroll-mt-24 {
   scroll-margin-top: 6rem;
 }
@@ -1123,6 +1143,10 @@ video {
 
 .grid-cols-3 {
   grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.grid-cols-\[1fr_2fr\] {
+  grid-template-columns: 1fr 2fr;
 }
 
 .grid-cols-\[1fr_auto_1fr\] {
@@ -1435,30 +1459,6 @@ video {
   background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
 }
 
-.bg-\[url\(\'\/img\/micro_exp\.webp\'\)\] {
-  background-image: url('/img/micro_exp.webp');
-}
-
-.bg-\[url\(\'\/img\/about_top\.webp\'\)\] {
-  background-image: url('/img/about_top.webp');
-}
-
-.bg-\[url\(\'\/img\/crutto_hero\.webp\'\)\] {
-  background-image: url('/img/crutto_hero.webp');
-}
-
-.bg-\[url\(\'\/img\/hanami_pic\.webp\'\)\] {
-  background-image: url('/img/hanami_pic.webp');
-}
-
-.bg-\[url\(\'\/img\/hero_img2\.webp\'\)\] {
-  background-image: url('/img/hero_img2.webp');
-}
-
-.bg-\[url\(\'\/img\/solar_exp\.webp\'\)\] {
-  background-image: url('/img/solar_exp.webp');
-}
-
 .from-blue-400 {
   --tw-gradient-from: #60a5fa var(--tw-gradient-from-position);
   --tw-gradient-to: rgb(96 165 250 / 0) var(--tw-gradient-to-position);
@@ -1467,6 +1467,10 @@ video {
 
 .to-blue-900 {
   --tw-gradient-to: #1e3a8a var(--tw-gradient-to-position);
+}
+
+.bg-contain {
+  background-size: contain;
 }
 
 .bg-cover {
@@ -1566,12 +1570,20 @@ video {
   padding-bottom: 2rem;
 }
 
+.pl-2 {
+  padding-left: 0.5rem;
+}
+
 .pl-3 {
   padding-left: 0.75rem;
 }
 
 .pl-6 {
   padding-left: 1.5rem;
+}
+
+.pr-8 {
+  padding-right: 2rem;
 }
 
 .pt-20 {
@@ -1588,6 +1600,10 @@ video {
 
 .text-center {
   text-align: center;
+}
+
+.text-right {
+  text-align: right;
 }
 
 .align-super {
@@ -1631,11 +1647,6 @@ video {
 .text-xs {
   font-size: 0.75rem;
   line-height: 1rem;
-}
-
-.text-3xl {
-  font-size: 1.875rem;
-  line-height: 2.25rem;
 }
 
 .font-bold {
@@ -1751,6 +1762,12 @@ video {
   transition-duration: 150ms;
 }
 
+.transition-\[max-height\] {
+  transition-property: max-height;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
 .transition-all {
   transition-property: all;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
@@ -1787,6 +1804,10 @@ video {
 
 .duration-500 {
   transition-duration: 500ms;
+}
+
+.duration-700 {
+  transition-duration: 700ms;
 }
 
 .ease-in-out {
@@ -1933,6 +1954,22 @@ video {
   --tw-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
   --tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\:outline-none:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+.focus\:ring-2:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus\:ring-blue-400:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(96 165 250 / var(--tw-ring-opacity, 1));
 }
 
 .peer:checked ~ .peer-checked\:right-0 {
@@ -2231,11 +2268,6 @@ video {
   .md\:text-xl {
     font-size: 1.25rem;
     line-height: 1.75rem;
-  }
-
-  .md\:text-4xl {
-    font-size: 2.25rem;
-    line-height: 2.5rem;
   }
 
   .md\:\[grid-template-columns\:repeat\(auto-fit\2c 400px\)\] {

--- a/httpdocs/src/input.css
+++ b/httpdocs/src/input.css
@@ -1,6 +1,5 @@
 @tailwind base;
 @tailwind components;
-@tailwind utilities;
 
 @layer components {
     /* 各行（grid 2 列） */
@@ -18,7 +17,7 @@
 
     /* 装飾付きテーブル要素 */
     .design_table {
-        @apply w-full border-collapse text-xs md:text-sm md:text-base;
+        @apply w-full border-collapse text-xs md:text-sm;
     }
 
     .design_table tr {
@@ -58,3 +57,5 @@
         @apply overflow-hidden max-h-0 px-2 transition-[max-height] duration-700 ease-in-out;
     }
 }
+
+@tailwind utilities;

--- a/httpdocs/tailwind.config.js
+++ b/httpdocs/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-    content: ["./**/*.{php,html}", "./js/**/*.js"],
+    content: ["./**/*.{php,html}", "./js/**/*.js", "./src/input.css"],
+
     theme: {
         extend: {},
     },


### PR DESCRIPTION
index.phpの会社概要部分で、PC表示は問題ないがモバイルだと「もっと見る」ボタンが反応しない点を修正。
・見た目ではわからないが、画像部分がテキストよりも上に来ている扱いらしい。
・z-indexでテキストを上になるよう調整。

tailwindの仕様変更等により、当初書いたコードがうまく動かないことがある。
・@referenceを用いて一工夫入れないと、@apply内だけで使用しているクラスは「使われていない」と判断されて削除されてしまう。
→ podman-compose up時に「unknown class」と判断されてコンテナがビルドできない。

> 解決方法は未だゴチャついているようなので、ビルド時は一旦@apply関連消してから再帰するしか現状の自分には手立てがない。

・画像がうまく表示されない。
→ `<?php echo htmlspecialchars($hero_bg, ENT_QUOTES); ?>`この部分をクラスに入れ込んでしまうと、<br>
tailwindがビルド時はまだ正確なクラスとして存在しないので反映されないっぽい。

> `style="background-image: url('<?php echo htmlspecialchars($hero_bg, ENT_QUOTES); ?>');">`として、<br>
予め画像を適用してしまうのが無難。